### PR TITLE
Fix '_open' method in fits saving handler

### DIFF
--- a/control/src/CtSaving_Fits.cpp
+++ b/control/src/CtSaving_Fits.cpp
@@ -56,7 +56,8 @@ SaveContainerFits::~SaveContainerFits()
 }
 
 void* SaveContainerFits::_open(const std::string &filename,
-			       std::ios_base::openmode openFlags)
+			       std::ios_base::openmode openFlags,
+			       CtSaving::Parameters& /*pars*/)
 {
   DEB_MEMBER_FUNCT();
   return new std::string("!" + filename + ".fits");

--- a/control/src/CtSaving_Fits.h
+++ b/control/src/CtSaving_Fits.h
@@ -37,7 +37,8 @@ namespace lima {
     virtual ~SaveContainerFits();
   protected:
     virtual void* _open(const std::string &filename,
-		       std::ios_base::openmode flags);
+			std::ios_base::openmode flags,
+			CtSaving::Parameters& pars);
     virtual void _close(void*);
     virtual long _writeFile(void*,Data &data,
 			    CtSaving::HeaderMap &aHeader,


### PR DESCRIPTION
The '_open' method did not had enough parameters so the compiler complained about an abstract class and can't be used.